### PR TITLE
Update setup to a newer version 0.2.0 to avoid conflicts in PIP registry

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup
 from setuptools.command.install import install
 
-VERSION = "0.1.9"
+VERSION = "0.2.0"
 
 
 def readme():


### PR DESCRIPTION
Update setup.py to a newer version 0.2.0 to avoid conflicts with existing package during continuous deployent in CircleCI